### PR TITLE
Restructure entry file bundle logic to support "layering"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5125,6 +5125,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "node_modules/babel-plugin-compact-reexports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-compact-reexports/-/babel-plugin-compact-reexports-1.1.0.tgz",
+      "integrity": "sha512-+KgjNJ5yMeZzJxYZdLEy9m82m92aL7FLvNJcK6dYJbW06t+UTpFJ2FVSs35zMfURcPnrQELYhLG4VC+kt/4gvw==",
+      "dev": true
+    },
     "node_modules/babel-plugin-debug-macros": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
@@ -6417,6 +6423,68 @@
         "object-assign": "^4.1.0",
         "path-posix": "^1.0.0",
         "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/broccoli-dependency-funnel": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-dependency-funnel/-/broccoli-dependency-funnel-2.1.2.tgz",
+      "integrity": "sha512-k6b0OnNuRcUnJ9TXA0o6RvqXOkTQ6APKoLsZeMJHAe/YjLjE1uTlfw4Z88GfGmi8gwtLHdnkrhBoJ7YdIkcVZA==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^1.3.1",
+        "fs-tree-diff": "^0.5.9",
+        "heimdalljs": "^0.2.5",
+        "heimdalljs-logger": "^0.1.9",
+        "mkdirp": "^0.5.1",
+        "mr-dep-walk": "^1.4.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.6.2",
+        "symlink-or-copy": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/broccoli-dependency-funnel/node_modules/broccoli-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
+      "dependencies": {
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^2.3.4",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/broccoli-dependency-funnel/node_modules/fs-tree-diff": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+      "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+      "dev": true,
+      "dependencies": {
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      }
+    },
+    "node_modules/broccoli-dependency-funnel/node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "node_modules/broccoli-dependency-funnel/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/broccoli-file-creator": {
@@ -9558,6 +9626,23 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
       "dev": true
+    },
+    "node_modules/ember-asset-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-asset-loader/-/ember-asset-loader-1.0.0.tgz",
+      "integrity": "sha512-JXr9bEkkzXiamW2kMk36U2VugLzo4MeoTQGRxvpNFqU1oldUMzm/yFPVvtjsVOjishH4pVwQuOK9Sjrx9E2xZg==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-caching-writer": "^3.0.3",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-merge-trees": "^4.2.0",
+        "ember-cli-babel": "^7.26.11",
+        "fs-extra": "^10.1.0",
+        "walk-sync": "^3.0.0"
+      },
+      "engines": {
+        "node": "14.* || 16.* || >= 17"
+      }
     },
     "node_modules/ember-auto-import": {
       "resolved": "packages/ember-auto-import",
@@ -15865,6 +15950,43 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/ember-engines": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ember-engines/-/ember-engines-0.9.0.tgz",
+      "integrity": "sha512-LVb1GrLGU2DXLXL2ynYXPHg0JJ6P3LRciOdDfjP0aRPLZ1evOr0h7IPIDq4SsT2nG0yhX5qBMJNB4NCyFZvcyA==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/macros": "^1.3.0",
+        "amd-name-resolver": "1.3.1",
+        "babel-plugin-compact-reexports": "^1.1.0",
+        "broccoli-babel-transpiler": "^7.2.0",
+        "broccoli-concat": "^4.2.5",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-dependency-funnel": "^2.1.2",
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-merge-trees": "^4.2.0",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "ember-asset-loader": "^1.0.0",
+        "ember-cli-babel": "^7.18.0",
+        "ember-cli-preprocess-registry": "^3.3.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-version-checker": "^5.1.2",
+        "lodash": "^4.17.11"
+      },
+      "engines": {
+        "node": "14.* || 16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@ember/legacy-built-in-components": "*",
+        "ember-source": "^3.24.1 || 4"
+      },
+      "peerDependenciesMeta": {
+        "@ember/legacy-built-in-components": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ember-export-application-global": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
@@ -21145,9 +21267,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -26680,6 +26802,58 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mr-dep-walk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mr-dep-walk/-/mr-dep-walk-1.4.0.tgz",
+      "integrity": "sha512-UaDUqkLsd0ep3jAx2+A7BIpfw8wKxhthDj3yPNLBnevipK1CUFJJiz24jRVLw18q7R2aEiRq13WwUBlnwfbQqQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^5.1.1",
+        "amd-name-resolver": "^0.0.6",
+        "fs-extra": "^3.0.1"
+      }
+    },
+    "node_modules/mr-dep-walk/node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/mr-dep-walk/node_modules/amd-name-resolver": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz",
+      "integrity": "sha1-0+S6Lfyqsdggwb6d6UfGeCjP5ZU=",
+      "dev": true,
+      "dependencies": {
+        "ensure-posix-path": "^1.0.1"
+      }
+    },
+    "node_modules/mr-dep-walk/node_modules/fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/mr-dep-walk/node_modules/jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/ms": {
@@ -34209,6 +34383,7 @@
         "ember-cli-typescript-2": "npm:ember-cli-typescript@^2.0.0-beta.3",
         "ember-cli-typescript-3": "npm:ember-cli-typescript@^3.0.0",
         "ember-cli-typescript-4": "npm:ember-cli-typescript@^4.0.0-alpha.1",
+        "ember-engines": "^0.9.0",
         "ember-source-3": "npm:ember-source@^3.0.0",
         "ember-source-beta": "npm:ember-source@beta",
         "ember-source-canary": "npm:ember-source@alpha",
@@ -36176,6 +36351,7 @@
         "ember-cli-typescript-2": "npm:ember-cli-typescript@^2.0.0-beta.3",
         "ember-cli-typescript-3": "npm:ember-cli-typescript@^3.0.0",
         "ember-cli-typescript-4": "npm:ember-cli-typescript@^4.0.0-alpha.1",
+        "ember-engines": "^0.9.0",
         "ember-source-3": "npm:ember-source@^3.0.0",
         "ember-source-beta": "npm:ember-source@beta",
         "ember-source-canary": "npm:ember-source@alpha",
@@ -39592,6 +39768,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-compact-reexports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-compact-reexports/-/babel-plugin-compact-reexports-1.1.0.tgz",
+      "integrity": "sha512-+KgjNJ5yMeZzJxYZdLEy9m82m92aL7FLvNJcK6dYJbW06t+UTpFJ2FVSs35zMfURcPnrQELYhLG4VC+kt/4gvw==",
+      "dev": true
+    },
     "babel-plugin-debug-macros": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz",
@@ -40791,6 +40973,64 @@
             "object-assign": "^4.1.0",
             "path-posix": "^1.0.0",
             "symlink-or-copy": "^1.1.8"
+          }
+        }
+      }
+    },
+    "broccoli-dependency-funnel": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-dependency-funnel/-/broccoli-dependency-funnel-2.1.2.tgz",
+      "integrity": "sha512-k6b0OnNuRcUnJ9TXA0o6RvqXOkTQ6APKoLsZeMJHAe/YjLjE1uTlfw4Z88GfGmi8gwtLHdnkrhBoJ7YdIkcVZA==",
+      "dev": true,
+      "requires": {
+        "broccoli-plugin": "^1.3.1",
+        "fs-tree-diff": "^0.5.9",
+        "heimdalljs": "^0.2.5",
+        "heimdalljs-logger": "^0.1.9",
+        "mkdirp": "^0.5.1",
+        "mr-dep-walk": "^1.4.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.6.2",
+        "symlink-or-copy": "^1.2.0"
+      },
+      "dependencies": {
+        "broccoli-plugin": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+          "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+          "dev": true,
+          "requires": {
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+          "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
           }
         }
       }
@@ -43413,6 +43653,20 @@
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
           "dev": true
         }
+      }
+    },
+    "ember-asset-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-asset-loader/-/ember-asset-loader-1.0.0.tgz",
+      "integrity": "sha512-JXr9bEkkzXiamW2kMk36U2VugLzo4MeoTQGRxvpNFqU1oldUMzm/yFPVvtjsVOjishH4pVwQuOK9Sjrx9E2xZg==",
+      "dev": true,
+      "requires": {
+        "broccoli-caching-writer": "^3.0.3",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-merge-trees": "^4.2.0",
+        "ember-cli-babel": "^7.26.11",
+        "fs-extra": "^10.1.0",
+        "walk-sync": "^3.0.0"
       }
     },
     "ember-auto-import": {
@@ -48900,6 +49154,31 @@
       "integrity": "sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=",
       "dev": true
     },
+    "ember-engines": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ember-engines/-/ember-engines-0.9.0.tgz",
+      "integrity": "sha512-LVb1GrLGU2DXLXL2ynYXPHg0JJ6P3LRciOdDfjP0aRPLZ1evOr0h7IPIDq4SsT2nG0yhX5qBMJNB4NCyFZvcyA==",
+      "dev": true,
+      "requires": {
+        "@embroider/macros": "^1.3.0",
+        "amd-name-resolver": "1.3.1",
+        "babel-plugin-compact-reexports": "^1.1.0",
+        "broccoli-babel-transpiler": "^7.2.0",
+        "broccoli-concat": "^4.2.5",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-dependency-funnel": "^2.1.2",
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-merge-trees": "^4.2.0",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "ember-asset-loader": "^1.0.0",
+        "ember-cli-babel": "^7.18.0",
+        "ember-cli-preprocess-registry": "^3.3.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-version-checker": "^5.1.2",
+        "lodash": "^4.17.11"
+      }
+    },
     "ember-export-application-global": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz",
@@ -53115,9 +53394,9 @@
       }
     },
     "fs-extra": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
-      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -57588,6 +57867,54 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.6"
+          }
+        }
+      }
+    },
+    "mr-dep-walk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mr-dep-walk/-/mr-dep-walk-1.4.0.tgz",
+      "integrity": "sha512-UaDUqkLsd0ep3jAx2+A7BIpfw8wKxhthDj3yPNLBnevipK1CUFJJiz24jRVLw18q7R2aEiRq13WwUBlnwfbQqQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.1.1",
+        "amd-name-resolver": "^0.0.6",
+        "fs-extra": "^3.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
+        "amd-name-resolver": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz",
+          "integrity": "sha1-0+S6Lfyqsdggwb6d6UfGeCjP5ZU=",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^3.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
           }
         }
       }

--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -67,7 +67,7 @@ export default class AutoImport implements AutoImportSharedAPI {
     this.packages.add(Package.lookupParentOf(topmostAddon));
     let host = topmostAddon.app;
     this.env = host.env;
-    this.bundles = new BundleConfig(host.options.outputPaths);
+    this.bundles = new BundleConfig(host.options.outputPaths, host);
     if (!this.env) {
       throw new Error('Bug in ember-auto-import: did not discover environment');
     }

--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -4,6 +4,7 @@
 */
 
 import { dirname } from 'path';
+import { AppInstance } from '@embroider/shared-internals';
 const testsPattern = new RegExp(`^(@[^/]+)?/?[^/]+/(tests|test-support)/`);
 
 import type { TreeType } from './analyzer';
@@ -26,12 +27,16 @@ interface OutputPaths {
 }
 
 export default class BundleConfig {
-  constructor(private outputPaths: OutputPaths) {}
+  constructor(private outputPaths: OutputPaths, private host?: AppInstance) {}
 
   // This list of valid bundles, in priority order. The first one in the list that
   // needs a given import will end up with that import.
   get names(): ReadonlyArray<BundleName> {
     return Object.freeze(['app', 'tests']);
+  }
+
+  get hostProject() {
+    return this.host!.project;
   }
 
   isBuiltInBundleName(name: string): name is BundleName {

--- a/packages/ember-auto-import/ts/inserter.ts
+++ b/packages/ember-auto-import/ts/inserter.ts
@@ -110,6 +110,10 @@ export class Inserter extends Plugin {
     let ast = parse5.parse(html, { sourceCodeLocationInfo: true });
     let stringInserter = new StringInserter(html);
 
+    // make sure we do not duplicate scripts that would
+    // be added to the test html file.
+    let insertedScriptAssets: Set<string> = new Set();
+
     if (this.options.insertScriptsAt) {
       debug(
         `looking for custom script element: %s`,
@@ -160,7 +164,8 @@ export class Inserter extends Plugin {
             fastbootInfo,
             stringInserter,
             element,
-            src
+            src,
+            insertedScriptAssets
           );
         }
       }
@@ -233,7 +238,8 @@ export class Inserter extends Plugin {
     fastbootInfo: ReturnType<typeof Inserter.prototype.fastbootManifestInfo>,
     stringInserter: StringInserter,
     element: parse5.Element,
-    src: string
+    src: string,
+    insertedScriptAssets: Set<string>
   ) {
     for (let entry of targets.scripts) {
       if (entry.afterFile && src.endsWith(entry.afterFile)) {
@@ -241,6 +247,14 @@ export class Inserter extends Plugin {
         entry.inserted = true;
         debug(`inserting %s`, scriptChunks);
         let insertedSrc = scriptChunks
+          .filter((s) => {
+            if (insertedScriptAssets.has(s)) {
+              return false;
+            }
+
+            insertedScriptAssets.add(s);
+            return true;
+          })
           .map((chunk) => `\n<script src="${this.chunkURL(chunk)}"></script>`)
           .join('');
         if (fastbootInfo?.readsHTML && bundleName === 'app') {

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -238,7 +238,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
         library: '__ember_auto_import__',
       },
       optimization: {
-        removeAvailableModules: true,
+        removeAvailableModules: this.opts.environment === 'production',
         splitChunks: {
           chunks: 'all',
         },

--- a/test-scenarios/engines-test.ts
+++ b/test-scenarios/engines-test.ts
@@ -1,0 +1,250 @@
+import { appScenarios } from './scenarios';
+import { PreparedApp, Project } from 'scenario-tester';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+import { dirname } from 'path';
+const { module: Qmodule, test } = QUnit;
+
+// Both ember-engines and its dependency ember-asset-loader have undeclared
+// peerDependencies on ember-cli.
+function emberEngines(): Project {
+  let enginesPath = dirname(require.resolve('ember-engines/package.json'));
+  let engines = Project.fromDir(enginesPath, { linkDeps: true });
+  engines.pkg.peerDependencies = Object.assign({ 'ember-cli': '*' }, engines.pkg.peerDependencies);
+  let assetLoader = Project.fromDir(dirname(require.resolve('ember-asset-loader', { paths: [enginesPath] })), {
+    linkDeps: true,
+  });
+  assetLoader.pkg.peerDependencies = Object.assign({ 'ember-cli': '*' }, assetLoader.pkg.peerDependencies);
+  engines.addDependency(assetLoader);
+  return engines;
+}
+
+function createInRepoEngine(project: Project, engineName: string) {
+  let engineProject = emberEngines();
+  project.addDependency(engineProject);
+
+  if (project.pkg['ember-addon'] && (project.pkg['ember-addon'] as any).paths) {
+    ((project.pkg['ember-addon'] as any).paths as any).push(`lib/${engineName}`);
+  } else {
+    project.pkg['ember-addon'] = {
+      paths: [`lib/${engineName}`],
+    };
+  }
+
+  merge(project.files, {
+    lib: {
+      [engineName]: {
+        'index.js': `const EngineAddon = require('ember-engines/lib/engine-addon');
+module.exports = EngineAddon.extend({
+  name: '${engineName}',
+  lazyLoading: {
+    enabled: true,
+  },
+});`,
+        'package.json': `{
+  "name": "${engineName}",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-auto-import": "*",
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*",
+    "webpack": "*",
+    "fake-package": "*",
+    "outer2": "*"
+  },
+  "devDependencies": {
+    "ember-engines": "*"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}`,
+        config: {
+          'environment.js': `/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+let ENV = {
+  modulePrefix: '${engineName}',
+  environment
+};
+
+return ENV;
+};`,
+        },
+        addon: {
+          routes: {
+            'application.js': `import Route from '@ember/routing/route';
+import fakePkg from 'fake-package';
+import { nonce } from 'outer2';
+
+export default class ApplicationRoute extends Route {
+  model() {
+    return {
+      pkgName: fakePkg(),
+      nonce,
+    };
+  }
+}`,
+          },
+          templates: {
+            'application.hbs': `<p data-test-pkg-name>{{this.model.pkgName}}</p><p data-test-nonce>{{this.model.nonce}}</p>`,
+          },
+          'engine.js': `import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const Eng = Engine.extend({
+  modulePrefix,
+  Resolver
+});
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;`,
+          'resolver.js': `import Resolver from 'ember-resolver';
+export default Resolver;`,
+          'routes.js': `import buildRoutes from 'ember-engines/routes';
+export default buildRoutes(function () {});`,
+        },
+      },
+    },
+  });
+
+  return engineProject;
+}
+
+// This is testing that an inrepo lazy engine which imports (via auto-import) a plain
+// npm package works correctly (ie the npm package should not be eagerly added).
+appScenarios
+  .skip('release') // ember-engines doesn't have an ember 4.0 compatible release yet.
+  .skip('beta')
+  .skip('canary')
+  .map('engines', project => {
+    project.linkDependency('ember-auto-import', { baseDir: __dirname });
+    project.linkDependency('webpack', { baseDir: __dirname });
+
+    createInRepoEngine(project, 'lazy-in-repo-engine');
+
+    project.addDevDependency('fake-package', {
+      files: {
+        'index.js': `module.exports = function() {
+          return 'fake-package';
+        }`,
+      },
+    });
+
+    project.addDevDependency('inner', {
+      files: {
+        'index.js': `
+          export const nonce = Math.floor(Math.random() * 1000000);
+        `,
+      },
+    });
+
+    // if we let the app and the engine both directly auto-import "inner",
+    // ember-auto-import's own deduplication logic would ensure there's no
+    // duplication of code or state.
+    //
+    // But that only covers the top-level dependencies. All deeper dependencies
+    // are managed directly by webpack, and we also need those dependencies not
+    // to get duplicated module state.
+    //
+    // So this test gives the app and engine different first-level dependencies
+    // (outer1 and outer2) that both share a deeper dependency (inner).
+    for (let outer of ['outer1', 'outer2']) {
+      let dep = project.addDevDependency(outer, {
+        files: {
+          'index.js': `
+          export { nonce } from 'inner';
+        `,
+        },
+      });
+      dep.pkg.peerDependencies = { inner: '*' };
+      project.addDevDependency(dep);
+    }
+
+    merge(project.files, {
+      app: {
+        'router.js': `import EmberRouter from '@ember/routing/router';
+import config from './config/environment';
+
+const Router = EmberRouter.extend({
+  location: config.locationType,
+  rootURL: config.rootURL,
+});
+
+Router.map(function() {
+  this.mount('lazy-in-repo-engine', { path: '/use-lazy-engine', as: 'use-lazy-engine' });
+});
+
+export default Router;`,
+        templates: {
+          'index.hbs': '<div data-test-nonce>{{this.model.nonce}}</div>',
+        },
+        routes: {
+          'index.js': `import Route from '@ember/routing/route';
+          import { nonce } from 'outer1';
+
+          export default class IndexRoute extends Route {
+            model() {
+              return { nonce };
+            }
+          }`,
+        },
+      },
+      tests: {
+        acceptance: {
+          'basic-test.js': `import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | basics', function (hooks) {
+  setupApplicationTest(hooks);
+
+  // To control module caching behaviors, we intentionally only have a single test here that
+  // exercises everything we want to exercise. If we added more tests, their order could effect
+  // the outcome of when lazy modules are visible.
+
+  test('lazy engine basics', async function (assert) {
+
+    // 1. importing a plain npm pacakge from a lazy engines does not add the package eagerly
+
+    assert.strictEqual(requirejs.entries['fake-package'], undefined, 'fake-package should not be loaded before visting lazy engine');
+    await visit('/use-lazy-engine');
+    assert.strictEqual(typeof requirejs.entries['fake-package'], 'object', 'fake-package was loaded only after visting the engine');
+    assert
+      .dom('[data-test-pkg-name]')
+      .hasText('fake-package', 'The fake-package was correctly imported');
+
+    // 2. Deps that are shared between app and engine share the same module state
+
+    await visit('/');
+    let appNonce = document.querySelector('[data-test-nonce]').textContent;
+    await visit('/use-lazy-engine');
+    assert.dom('[data-test-nonce]').hasText(appNonce, 'app and addon should see same nonce');
+  });
+});`,
+        },
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test(`yarn test`, async function (assert) {
+        let result = await app.execute('volta run npm -- run test');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });

--- a/test-scenarios/merged-test.ts
+++ b/test-scenarios/merged-test.ts
@@ -5,6 +5,7 @@ import merge from 'lodash/merge';
 const { module: Qmodule, test } = QUnit;
 
 appScenarios
+  .skip('lts') // webpack will duplicate the inner module when ember-welcome-page is on v5
   .map('merged', project => {
     let innerLib = project.addDevDependency('inner-lib', {
       files: {

--- a/test-scenarios/package.json
+++ b/test-scenarios/package.json
@@ -37,6 +37,7 @@
     "ember-cli-typescript-2": "npm:ember-cli-typescript@^2.0.0-beta.3",
     "ember-cli-typescript-3": "npm:ember-cli-typescript@^3.0.0",
     "ember-cli-typescript-4": "npm:ember-cli-typescript@^4.0.0-alpha.1",
+    "ember-engines": "^0.9.0",
     "ember-source-3": "npm:ember-source@^3.0.0",
     "ember-source-lts": "npm:ember-source@~3.4.0",
     "ember-source-beta": "npm:ember-source@beta",


### PR DESCRIPTION
Currently, ember-auto-import has two conceptual buckets where it places the imports it has found (an **app** bucket and a **tests** bucket). While this works, it has two potential problems. The first is with imports from within lazy engines as they get placed inside of the "app" bucket. This means that instead of these asset loading lazily they are instead eagerly loaded as part of the main app bundle. The second problem is that modules can be "duplicated" in each bucket and can cause problems with module states' being different depending on the importer.

In order to fix this, this PR creates an individual entry file (or bucket) for every addon that is doing an import. It then creates import links from each entry file to its rightful parent (ie a nested addon from a lazy engine would only be imported from the lazy engine's entry file and then the lazy engine's entry file is import from the app's entry file dynamically). Additionally, the tests entry file now imports the app entry file which creates a conceptual graph for webpack to properly traverse such that modules will not be duplicated.

Fixes: #503