### PR TITLE
omit dependencies bundled with ember-source from participating in the webpack fun 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34223,6 +34223,7 @@
         "lodash-es": "^4.17.10",
         "moment": "^2.22.1",
         "old-analyzer": "npm:ember-auto-import@2.1.0",
+        "rsvp": "^4.0.0",
         "typescript-4": "npm:typescript@^4.1.2",
         "webpack": "^5.31.0"
       }
@@ -34563,6 +34564,15 @@
       "dev": true,
       "engines": {
         "node": "10.* || >= 12.*"
+      }
+    },
+    "test-scenarios/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
       }
     },
     "test-scenarios/node_modules/sane": {
@@ -36192,6 +36202,7 @@
         "moment": "^2.22.1",
         "old-analyzer": "npm:ember-auto-import@2.1.0",
         "qunit": "^2.6.1",
+        "rsvp": "^4.0.0",
         "scenario-tester": "^2.1.2",
         "ts-node": "^9.1.1",
         "typescript-4": "npm:typescript@^4.1.2",
@@ -36477,6 +36488,12 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
           "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+          "dev": true
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
           "dev": true
         },
         "sane": {

--- a/packages/ember-auto-import/ts/splitter.ts
+++ b/packages/ember-auto-import/ts/splitter.ts
@@ -35,6 +35,7 @@ export interface SplitterOptions {
   // list of bundle names in priority order
   bundles: BundleConfig;
   analyzers: Map<Analyzer, Package>;
+  isPreBundled: (specifier: string) => boolean;
 }
 
 export default class Splitter {
@@ -243,6 +244,10 @@ export default class Splitter {
     });
 
     for (let target of targets.targets.values()) {
+      if (this.options.isPreBundled(target.specifier)) {
+        continue;
+      }
+
       let [dynamicUses, staticUses] = partition(
         target.importedBy,
         (imp) => imp.isDynamic

--- a/packages/ember-auto-import/ts/tests/splitter-test.ts
+++ b/packages/ember-auto-import/ts/tests/splitter-test.ts
@@ -82,6 +82,7 @@ Qmodule('splitter', function (hooks) {
           },
         }),
         analyzers: new Map([[analyzer, pack]]),
+        isPreBundled: () => false,
       });
       builder = new broccoli.Builder(analyzer);
     };

--- a/test-scenarios/package.json
+++ b/test-scenarios/package.json
@@ -47,6 +47,7 @@
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.10",
     "moment": "^2.22.1",
+    "rsvp": "^4.0.0",
     "typescript-4": "npm:typescript@^4.1.2",
     "webpack": "^5.31.0"
   },

--- a/test-scenarios/v2-addon-test.ts
+++ b/test-scenarios/v2-addon-test.ts
@@ -497,8 +497,37 @@ Scenarios.fromProject(baseApp)
       },
     });
 
+    /**
+      * RSVP is included with ember, and we should defer to
+      * the ember copy when RSVP is imported.
+      *
+      * Reasons for including RSVP in a package.json:
+      * - types
+      * - node usage
+      *
+      * Issue came up here: https://github.com/ef4/ember-auto-import/issues/564
+      *
+      * Note that we dont' even need to import this package for the problem to occur
+      * (if you undo the fix accompanying this test change)
+      */
+    let v1Addon_declaresRSVP = baseAddon();
+    v1Addon_declaresRSVP.pkg.name = 'v1-addon_2';
+    merge(v1Addon_declaresRSVP.files, {
+      addon: {
+        'index.js': `
+          import * as RSVP from 'rsvp';
+          export const Promise = RSVP.Promise;
+        `
+      },
+    });
+
+    v1Addon_declaresRSVP.linkDependency('ember-auto-import', { baseDir: __dirname });
+    v1Addon_declaresRSVP.linkDependency('webpack', { baseDir: __dirname });
+    v1Addon_declaresRSVP.linkDependency('rsvp', { baseDir: __dirname });
+
     project.addDependency(v2Addon);
     project.addDependency(v1Addon);
+    project.addDependency(v1Addon_declaresRSVP);
 
     project.linkDependency('ember-auto-import', { baseDir: __dirname });
     project.linkDependency('webpack', { baseDir: __dirname });


### PR DESCRIPTION
Resolves: https://github.com/ef4/ember-auto-import/issues/564
Eliminates, what I believe to be a require-cycle:
- rsvp is require'd
- rsvp previously depended on the early boot set
- but the early boot set contains dependencies which depend on rsvp (`@ember/object` / mixins, etc)

-------

further investigations after the embroider office hours:

 - is rsvp duplicated?
   - `yarn why rsvp`
      ```
      ❯ yarn why rsvp
      yarn why v1.22.19
      [1/4] 🤔  Why do we have the module "rsvp"...?
      [2/4] 🚚  Initialising dependency graph...
      [3/4] 🔍  Finding dependency...
      [4/4] 🚡  Calculating file sizes...
      => Found "rsvp@4.8.5"
      info Has been hoisted to "rsvp"
      info Reasons this module exists
         - Hoisted from "ember-bootstrap#rsvp"
         - Hoisted from "ember-cli-typescript#rsvp"
      ```    
      yes
- why is rsvp used in `ember-bootstrap`?
   - no types, so the types from rsvp are not used
   - used in node for tests, so dep must exist so node knows where to find it
   - in browser (the addon code), the rsvp-shipped-with-ember would be sufficient      
- does `autoImport.exclude` with `rsvp` fix the problem?
  - from the app: no
  - from ember-bootstrap: yes
    ```js
    // node_modules/ember-bootstrap/index.js
    options: {
      '@embroider/macros': {
        setOwnConfig: {},
      },
      autoImport: {
        exclude: ['rsvp'],
      }
    }
     ``` 



**Path forward**
  ensure that [these dependencies](https://github.com/emberjs/ember.js/pull/20349/files#diff-92bbac9a308cd5fcf9db165841f2d90ce981baddcb2b1e26cfff170929af3bd1R169) are always excluded from ember-auto-import (at least until ember-source becomes a real package)