### PR TITLE
Add link from top level changelog to actual changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-packages/ember-auto-import/CHANGELOG.md
+[packages/ember-auto-import/CHANGELOG.md](https://github.com/embroider-build/ember-auto-import/blob/main/packages/ember-auto-import/CHANGELOG.md)


### PR DESCRIPTION
Hi there! I suggest updating the top level changelog to link to the actual changelog. Minor, but it makes life easier for readers looking for the changelog. Thanks!