### PR TITLE
Enable `bugfixes: true` to Babel's config

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -575,6 +575,7 @@ export default class Package {
         [
           require.resolve('@babel/preset-env'),
           {
+            bugfixes: true,
             modules: false,
             targets: parent.targets,
           },


### PR DESCRIPTION
That leads to (much) smaller code and will be the default in Babel 8. I got to that because my `targets` contains `safari >= 16` but due to [this](https://github.com/babel/babel/issues/13916) code was transpiled for much older browsers. I fixed the problem for classic packages in Ember (by adding `bugfixes: true` to `babel` in `ember-cli-build.js`) but for `ember-auto-import`ed ones I couldn't - this flag is needed for them.

@ef4 have I done the correct thing here?