### PR TITLE
Allow arbitrary extensions for app-imports

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -419,7 +419,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
   *withResolvableExtensions(
     importSpecifier: string
   ): Generator<string, void, void> {
-    if (importSpecifier.match(/\.\w{1,3}$/)) {
+    if (importSpecifier.match(/\.\w+$/)) {
       yield importSpecifier;
     } else {
       for (let ext of EXTENSIONS) {


### PR DESCRIPTION
With a config like `allowAppImports: ['images/**/*.webp']` and importing a file like `image.webp`, eai would fail to handle that import properly, as it assumes that explicit extensions would be 1-3 characters long.

With a proper webpack loader we can make it import any type of file, so we shouldn't make assumptions about the possible extensions.