### PR TITLE
Fix imports with a query part

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -13,6 +13,7 @@ import semver from 'semver';
 import type { TransformOptions } from '@babel/core';
 import { MacrosConfig } from '@embroider/macros/src/node';
 import minimatch from 'minimatch';
+import { stripQuery } from './util';
 
 // from child addon instance to their parent package
 const parentCache: WeakMap<AddonInstance, Package> = new WeakMap();
@@ -315,7 +316,9 @@ export default class Package {
     if (!this.isAddon && packageName === this.name) {
       let localPath = path.slice(packageName.length + 1);
       if (
-        this.allowAppImports.some((pattern) => minimatch(localPath, pattern))
+        this.allowAppImports.some((pattern) =>
+          minimatch(stripQuery(localPath), pattern)
+        )
       ) {
         return {
           type: 'package',

--- a/packages/ember-auto-import/ts/util.ts
+++ b/packages/ember-auto-import/ts/util.ts
@@ -6,3 +6,7 @@ export function shallowEqual(a: any[], b: any[]) {
     a.every((item, index) => item === b[index])
   );
 }
+
+export function stripQuery(path: string) {
+  return path.split('?')[0];
+}


### PR DESCRIPTION
With the new `allowAppImports` feature, apps can import resources that are handled with custom webpack loaders. Some can allow you to customize their behavior by passing query params, like `import image from './images/image.jpg?size=1024`.

This PR is fixing two related issues:
* make sure that an `allowAppImports` glob like `'images/**/*.jpg'` would also match for imports that include query params, by stripping the query part before trying to match the import to the glob
* query params could technically also include quotes. These already got escaped when building the app-chunk that has the AMD-shims, but the regex to replace `EAI_DISCOVERED_EXTERNALS` was not taking their possible existence into account correctly, leaving `EAI_DISCOVERED_EXTERNALS` around in the final build.