### PR TITLE
fix the repo link in the published package

### DIFF
--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -17,7 +17,7 @@
   "main": "js/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ef4/ember-auto-import",
+    "url": "https://github.com/ember-auto-import/ember-auto-import",
     "directory": "packages/ember-auto-import"
   },
   "scripts": {

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -17,7 +17,7 @@
   "main": "js/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ember-auto-import/ember-auto-import",
+    "url": "https://github.com/embroider-build/ember-auto-import",
     "directory": "packages/ember-auto-import"
   },
   "scripts": {


### PR DESCRIPTION
I noticed this today while looking into an issue, but really I wanted to open a PR to prove that CI is currently failing for LTS