### PR TITLE
setup windows tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,12 +30,14 @@ jobs:
         run: for name in `ls packages/*/.eslintrc.js`; do dirname $name; done  | xargs npx eslint --
       - id: set-matrix
         working-directory: test-scenarios
-        run: echo "::set-output name=matrix::$(npm run --silent test:list -- --matrix 'npm run test -- --filter %s:')"
+        run: |
+          matrix_json=$(node --require ts-node/register ./suite-setup-util.ts)
+          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
 
   scenarios:
     needs: discover_matrix
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: '${{ matrix.os }}-latest'
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.discover_matrix.outputs.matrix)}}

--- a/test-scenarios/suite-setup-util.ts
+++ b/test-scenarios/suite-setup-util.ts
@@ -29,6 +29,9 @@ async function githubMatrix() {
     ...suites
       // only run release tests in windows for now as a smoke test and not slow down CI too much
       .filter(s => !['canary', 'beta', 'lts', 'ember3'].some(i => s.name.includes(i)))
+      // this test fails in windows because of a command imcompatibility with powershell.
+      // This is low priority but if someone had the time to look into PRs are welcome 👍
+      .filter(s => s.name !== 'release-sample-addon')
       .map(s => ({
         name: `${s.name} windows`,
         os: 'windows',

--- a/test-scenarios/suite-setup-util.ts
+++ b/test-scenarios/suite-setup-util.ts
@@ -1,0 +1,53 @@
+import execa from 'execa';
+
+async function githubMatrix() {
+  let { stdout } = await execa(
+    'npx',
+    [
+      'scenario-tester',
+      'list',
+      '--require',
+      'ts-node/register',
+      '--files',
+      '*-test.ts',
+      '--matrix',
+      'npm run test -- --filter %s',
+    ],
+    {
+      preferLocal: true,
+    }
+  );
+
+  let { include: suites } = JSON.parse(stdout) as { include: { name: string; command: string }[]; name: string[] };
+
+  let include = [
+    ...suites.map(s => ({
+      name: `${s.name} ubuntu`,
+      os: 'ubuntu',
+      command: s.command,
+    })),
+    ...suites
+      // only run release tests in windows for now as a smoke test and not slow down CI too much
+      .filter(s => !['canary', 'beta', 'lts', 'ember3'].some(i => s.name.includes(i)))
+      .map(s => ({
+        name: `${s.name} windows`,
+        os: 'windows',
+        command: s.command,
+      })),
+  ];
+
+  return {
+    name: include.map(s => s.name),
+    include,
+  };
+}
+
+async function main() {
+  const result = await githubMatrix();
+
+  process.stdout.write(JSON.stringify(result));
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
This implementation is taken (almost) exactly from what embroider is doing here: https://github.com/embroider-build/embroider/blob/main/test-packages/support/suite-setup-util.ts

Note: I'm filtering the tests that are running on Windows so as not to massively inflate the CI runtime. This PR increases the number of jobs on CI from 122 to 155. 