### PR TITLE
only check devDependencies when checking requested range of an app package

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -254,7 +254,6 @@ export default class Package {
     let { pkg } = this;
     return (
       pkg.dependencies?.[packageName] ||
-      pkg.devDependencies?.[packageName] ||
       pkg.peerDependencies?.[packageName]
     );
   }

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -252,9 +252,15 @@ export default class Package {
   // package.json
   requestedRange(packageName: string): string | undefined {
     let { pkg } = this;
-    return (
-      pkg.dependencies?.[packageName] || pkg.peerDependencies?.[packageName]
-    );
+    let result =
+      pkg.dependencies?.[packageName] || pkg.peerDependencies?.[packageName];
+
+    // only include devDeps if the package is an app
+    if (!result && !this.isAddon) {
+      result = pkg.devDependencies?.[packageName];
+    }
+
+    return result;
   }
 
   private hasNonDevDependency(name: string): boolean {

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -253,8 +253,7 @@ export default class Package {
   requestedRange(packageName: string): string | undefined {
     let { pkg } = this;
     return (
-      pkg.dependencies?.[packageName] ||
-      pkg.peerDependencies?.[packageName]
+      pkg.dependencies?.[packageName] || pkg.peerDependencies?.[packageName]
     );
   }
 


### PR DESCRIPTION
I noticed this when I was linking a package that had a peerDependency range wider than it's devDependencies (ember-showdown-prism)

i don't understand why we would ever want to check the requested range of a dev depdency of a package 🤔 but perhaps there is a nuance that I don't understand here and we need to encode that nuance into the question that is being asked