### PR TITLE
update release-plan CI jobs

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -4,9 +4,10 @@ on:
     branches:
       - main
       - master
-  pull_request:
+  pull_request_target: # This workflow has permissions on the repo, do NOT run code from PRs in this workflow. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     types:
       - labeled
+      - unlabeled
 
 concurrency:
   group: plan-release # only the latest one of these should ever be running
@@ -36,12 +37,13 @@ jobs:
     needs: check-plan
     permissions:
       contents: write
+      issues: read
       pull-requests: write
     outputs:
       explanation: ${{ steps.explanation.outputs.text }}
     # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
     # only run on labeled event if the PR has already been merged
-    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
 
     steps:
       - uses: actions/checkout@v4
@@ -55,14 +57,11 @@ jobs:
           node-version: 16
 
       - run: npm ci
-      
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
           set +e
-          
           npx release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
-          
 
           if [ $? -ne 0 ]; then
             echo 'text<<EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,11 +49,9 @@ jobs:
           node-version: 18
           # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
           registry-url: 'https://registry.npmjs.org'
-      
       - run: npm ci
       - name: npm publish
         run: npx release-plan publish
-      
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This fixes an issue where adding a label to a PR **from a fork** after it has been merged doesn't allow the release-plan job to run correctly

cc @simonihmig I noticed you had this exact issue with https://github.com/embroider-build/ember-auto-import/pull/623 