### PR TITLE
Fixing broccoli-debug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35261,7 +35261,7 @@
       }
     },
     "packages/ember-auto-import": {
-      "version": "2.7.4",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -3,7 +3,7 @@ import { Bundler, debugBundler } from './bundler';
 import Analyzer from './analyzer';
 import type { TreeType } from './analyzer';
 import Package from './package';
-import { buildDebugCallback } from 'broccoli-debug';
+import BroccoliDebug from 'broccoli-debug';
 import BundleConfig from './bundle-config';
 import type { Node } from 'broccoli-node-api';
 import { LeaderChooser } from './leader';
@@ -28,7 +28,7 @@ import path from 'path';
 import funnel from 'broccoli-funnel';
 import makeDebug from 'debug';
 
-const debugTree = buildDebugCallback('ember-auto-import');
+const debugTree = BroccoliDebug.buildDebugCallback('ember-auto-import');
 const debugWatch = makeDebug('ember-auto-import:watch');
 
 // This interface must be stable across all versions of ember-auto-import that

--- a/packages/ember-auto-import/ts/bundler.ts
+++ b/packages/ember-auto-import/ts/bundler.ts
@@ -3,10 +3,10 @@ import type Splitter from './splitter';
 import type Package from './package';
 import type BundleConfig from './bundle-config';
 import type { BundleName } from './bundle-config';
-import { buildDebugCallback } from 'broccoli-debug';
+import BroccoliDebug from 'broccoli-debug';
 import type webpack from 'webpack';
 
-const debugTree = buildDebugCallback('ember-auto-import');
+const debugTree = BroccoliDebug.buildDebugCallback('ember-auto-import');
 
 export interface BundlerOptions {
   consoleWrite: (msg: string) => void;

--- a/types/broccoli-debug/index.d.ts
+++ b/types/broccoli-debug/index.d.ts
@@ -1,8 +1,7 @@
 declare module 'broccoli-debug' {
-  import { InputNode, Node } from "broccoli-plugin";
+  import { InputNode, Node } from 'broccoli-plugin';
   export default class BroccoliDebug implements Tree {
     constructor(inputTree: InputNode, name: 'string');
-    __broccoliGetInfo__(): any;
+    static buildDebugCallback(name: string): (inputTree: InputNode, name: string) => Node;
   }
-  export function buildDebugCallback(name: string): (inputTree: InputNode, name: string) => Node;
 }


### PR DESCRIPTION
If you try to enable broccoli-debug these actually crash, because buildDebugCallback is really a static method that needs the correct `this`. This used to work, but something about the CJS-interop implementation changed at some point.