### PR TITLE
Renamed modules support

### DIFF
--- a/packages/ember-auto-import/ts/bundler.ts
+++ b/packages/ember-auto-import/ts/bundler.ts
@@ -15,7 +15,6 @@ export interface BundlerOptions {
   packages: Set<Package>;
   bundles: BundleConfig;
   webpack: typeof webpack;
-  v2Addons: Map<string, string>;
   rootPackage: Package;
 }
 

--- a/packages/ember-auto-import/ts/splitter.ts
+++ b/packages/ember-auto-import/ts/splitter.ts
@@ -10,7 +10,8 @@ import { satisfies } from 'semver';
 const debug = makeDebug('ember-auto-import:splitter');
 
 export interface ResolvedImport {
-  specifier: string;
+  requestedSpecifier: string;
+  resolvedSpecifier: string;
   packageName: string;
   packageRoot: string;
   importedBy: LiteralImport[];
@@ -115,7 +116,8 @@ export default class Splitter {
       seenAlready.importedBy.push(imp);
     } else {
       targets.set(imp.specifier, {
-        specifier: imp.specifier,
+        requestedSpecifier: imp.specifier,
+        resolvedSpecifier: target.resolvedSpecifier,
         packageName: target.packageName,
         packageRoot: target.packageRoot,
         importedBy: [imp],
@@ -284,9 +286,11 @@ export default class Splitter {
   }
 
   private sortBundle(bundle: BundleDependencies) {
-    bundle.staticImports.sort((a, b) => a.specifier.localeCompare(b.specifier));
+    bundle.staticImports.sort((a, b) =>
+      a.requestedSpecifier.localeCompare(b.requestedSpecifier)
+    );
     bundle.dynamicImports.sort((a, b) =>
-      a.specifier.localeCompare(b.specifier)
+      a.requestedSpecifier.localeCompare(b.requestedSpecifier)
     );
     bundle.dynamicTemplateImports.sort((a, b) =>
       a.cookedQuasis[0].localeCompare(b.cookedQuasis[0])
@@ -329,7 +333,8 @@ class LazyPrintDeps {
 
   private describeResolvedImport(imp: ResolvedImport) {
     return {
-      specifier: imp.specifier,
+      requestedSpecifier: imp.requestedSpecifier,
+      resolvedSpecifier: imp.resolvedSpecifier,
       packageRoot: imp.packageRoot,
       importedBy: imp.importedBy.map(this.describeImport.bind(this)),
     };

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -79,10 +79,10 @@ module.exports = (function(){
     return m && m.__esModule ? m : Object.assign({ default: m }, m);
   }
   {{#each staticImports as |module|}}
-    d('{{js-string-escape module.specifier}}', EAI_DISCOVERED_EXTERNALS('{{module-to-id module.specifier}}'), function() { return esc(require('{{js-string-escape module.specifier}}')); });
+    d('{{js-string-escape module.requestedSpecifier}}', EAI_DISCOVERED_EXTERNALS('{{module-to-id module.requestedSpecifier}}'), function() { return esc(require('{{js-string-escape module.resolvedSpecifier}}')); });
   {{/each}}
   {{#each dynamicImports as |module|}}
-    d('_eai_dyn_{{js-string-escape module.specifier}}', [], function() { return import('{{js-string-escape module.specifier}}'); });
+    d('_eai_dyn_{{js-string-escape module.requestedSpecifier}}', [], function() { return import('{{js-string-escape module.resolvedSpecifier}}'); });
   {{/each}}
   {{#each staticTemplateImports as |module|}}
     d('_eai_sync_{{js-string-escape module.key}}', [], function() {
@@ -105,8 +105,8 @@ module.exports = (function(){
 `,
   { noEscape: true }
 ) as (args: {
-  staticImports: { specifier: string }[];
-  dynamicImports: { specifier: string }[];
+  staticImports: { requestedSpecifier: string; resolvedSpecifier: string }[];
+  dynamicImports: { requestedSpecifier: string; resolvedSpecifier: string }[];
   staticTemplateImports: { key: string; args: string; template: string }[];
   dynamicTemplateImports: { key: string; args: string; template: string }[];
   publicAssetURL: string | undefined;
@@ -216,15 +216,12 @@ export default class WebpackBundler extends Plugin implements Bundler {
       resolve: {
         extensions: EXTENSIONS,
         mainFields: ['browser', 'module', 'main'],
-        alias: Object.assign(
-          {
-            // this is because of the allowAppImports feature needs to be able to import things
-            // like app-name/lib/something from within webpack handled code but that needs to be
-            // able to resolve to app-root/app/lib/something.
-            [this.opts.rootPackage.name]: `${this.opts.rootPackage.root}/app`,
-          },
-          ...removeUndefined([...this.opts.packages].map((pkg) => pkg.aliases))
-        ),
+        alias: Object.assign({
+          // this is because of the allowAppImports feature needs to be able to import things
+          // like app-name/lib/something from within webpack handled code but that needs to be
+          // able to resolve to app-root/app/lib/something.
+          [this.opts.rootPackage.name]: `${this.opts.rootPackage.root}/app`,
+        }),
       },
       plugins: removeUndefined([stylePlugin]),
       module: {

--- a/test-scenarios/v2-addon-test.ts
+++ b/test-scenarios/v2-addon-test.ts
@@ -56,6 +56,11 @@ function buildV2Addon() {
           );
         `,
       },
+      'special-module-dest.js': `
+        export default function() {
+          return "from a renamed module"
+        }
+      `,
     },
   });
   addon.linkDependency('@embroider/addon-shim', { baseDir: __dirname });
@@ -76,6 +81,9 @@ function buildV2Addon() {
     main: './addon-main.js',
     'app-js': {
       './components/hello-world.js': './app/components/hello-world.js',
+    },
+    'renamed-modules': {
+      'special-module/index.js': 'my-v2-addon/special-module-dest.js',
     },
   };
   return addon;
@@ -370,6 +378,16 @@ let scenarios = appScenarios.skip('lts').map('v2-addon', project => {
               assert.deepEqual(macroExample(), 'hello from the app');
             });
           });
+        `,
+        'renamed-modules-test.js': `
+          import { module, test } from 'qunit';
+          import special from 'special-module';
+
+          module('Unit | v2 addon renamed-modules', function () {
+            test('can import from v2 addon with renamed-modules', function (assert) {
+              assert.equal(special(), 'from a renamed module');
+            });
+          })
         `,
       },
     },


### PR DESCRIPTION
V2 addons are allowed to declare in their package.json that they offer `renamed-modules` for backward compatibility. For example, when we switch ember-source to publish as V2 [these names](https://github.com/emberjs/ember.js/blob/e1abff5ccd2fb747cdc53374936155d587740f72/package.json#L184) should be available directly through ember-auto-import.

Embroider uses `renamed-modules` extensively when auto-upgrading addons, but ember-auto-import doesn't support it yet. This PR will add it.