### PR TITLE
Disable ember-auto-import in vite projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 packages/*/node_modules
 packages/*/tmp
 packages/*/dist

--- a/packages/ember-auto-import/ts/index.ts
+++ b/packages/ember-auto-import/ts/index.ts
@@ -8,10 +8,49 @@ module.exports = {
 
   init(...args: any[]) {
     this._super.init.apply(this, args);
+
+    if (!this.isEnabled()) {
+      return;
+    }
+
     AutoImport.register(this);
   },
 
+  __host: null,
+  eldestGrandparent() {
+    if (this.__host !== null) return this.__host;
+
+    let parent = this.parent;
+    while (parent) {
+      if (!parent.parent) break;
+      parent = parent.parent;
+    }
+    this.__host = parent;
+    return this.__host;
+  },
+
+  __isEnabled: null,
+  isEnabled() {
+    if (this.__isEnabled !== null) return this.__isEnabled;
+
+    let host = this.eldestGrandparent();
+    let deps = new Set([
+      ...Object.keys(host.pkg.dependencies || {}),
+      ...Object.keys(host.pkg.devDependencies || {}),
+    ]);
+
+    let isViteProject = deps.has('@embroider/vite') && deps.has('vite');
+
+    this.__isEnabled = !isViteProject;
+
+    return this.__isEnabled;
+  },
+
   setupPreprocessorRegistry(type: string, registry: any) {
+    if (!this.isEnabled()) {
+      return;
+    }
+
     // we register on our parent registry (so we will process code
     // from the app or addon that chose to include us) rather than our
     // own registry (which would cause us to process our own code)
@@ -46,22 +85,34 @@ module.exports = {
 
   included(...args: unknown[]) {
     this._super.included.apply(this, ...args);
+    if (!this.isEnabled()) {
+      return;
+    }
     AutoImport.lookup(this).included(this);
   },
 
   // this exists to be called by @embroider/addon-shim
   registerV2Addon(packageName: string, packageRoot: string) {
+    if (!this.isEnabled()) {
+      return;
+    }
     AutoImport.lookup(this).registerV2Addon(packageName, packageRoot);
   },
 
   // this exists to be called by @embroider/addon-shim
   leader() {
+    if (!this.isEnabled()) {
+      return;
+    }
     return AutoImport.lookup(this);
   },
 
   // this only runs on top-level addons, so we don't need our own
   // !isDeepAddonInstance check here.
   postprocessTree(which: string, tree: Node): Node {
+    if (!this.isEnabled()) {
+      return tree;
+    }
     if (which === 'all') {
       return AutoImport.lookup(this).addTo(tree);
     } else {

--- a/packages/ember-auto-import/ts/index.ts
+++ b/packages/ember-auto-import/ts/index.ts
@@ -16,34 +16,8 @@ module.exports = {
     AutoImport.register(this);
   },
 
-  __host: null,
-  eldestGrandparent() {
-    if (this.__host !== null) return this.__host;
-
-    let parent = this.parent;
-    while (parent) {
-      if (!parent.parent) break;
-      parent = parent.parent;
-    }
-    this.__host = parent;
-    return this.__host;
-  },
-
-  __isEnabled: null,
   isEnabled() {
-    if (this.__isEnabled !== null) return this.__isEnabled;
-
-    let host = this.eldestGrandparent();
-    let deps = new Set([
-      ...Object.keys(host.pkg.dependencies || {}),
-      ...Object.keys(host.pkg.devDependencies || {}),
-    ]);
-
-    let isViteProject = deps.has('@embroider/vite') && deps.has('vite');
-
-    this.__isEnabled = !isViteProject;
-
-    return this.__isEnabled;
+    return process.env.EMBROIDER_PREBUILD !== 'true';
   },
 
   setupPreprocessorRegistry(type: string, registry: any) {


### PR DESCRIPTION
This prevents the error:
![image](https://github.com/user-attachments/assets/576d2c0f-0694-4376-8106-964a17a72b5d)


when using vite without ember-auto-import/webpack declared in your package.json.