### PR TITLE
add caching layer for discovered external chunks

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -135,6 +135,8 @@ export default class WebpackBundler extends Plugin implements Bundler {
 
   private lastBuildResult: BuildResult | undefined;
 
+  private outputCache = new Map<string, string>();
+
   constructor(priorTrees: InputNode[], private opts: BundlerOptions) {
     super(priorTrees, {
       persistentOutput: true,
@@ -509,6 +511,10 @@ export default class WebpackBundler extends Plugin implements Bundler {
           resolve(this.outputPath, assetFile),
           'utf8'
         );
+
+        if (this.outputCache.get(assetFile) === inputSrc) { continue; }
+        this.outputCache.set(assetFile, inputSrc);
+        
         let outputSrc = inputSrc.replace(
           /EAI_DISCOVERED_EXTERNALS\(['"]([^'"]+)['"]\)/g,
           (_substr: string, matched: string) => {


### PR DESCRIPTION
Trying the idea from https://github.com/embroider-build/ember-auto-import/issues/577#issuecomment-1568588073 to Fix #577 

Seems to work locally. Is caching the input OK or should it be the output?