### PR TITLE
Fix missing @glimmer/component error

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,7 +511,7 @@ importers:
         version: 1.10.0
       '@embroider/macros':
         specifier: npm:@embroider/macros@latest
-        version: 1.18.1
+        version: 1.19.1
       '@types/fs-extra':
         specifier: ^5.0.4
         version: 5.1.0
@@ -529,7 +529,7 @@ importers:
         version: link:../packages/ember-auto-import
       ember-cli:
         specifier: npm:ember-cli@alpha
-        version: 6.8.0-alpha.5(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
+        version: 6.9.0-alpha.1(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
       ember-cli-3:
         specifier: npm:ember-cli@^3.0.0
         version: ember-cli@3.28.6(babel-core@6.26.3)(encoding@0.1.13)(handlebars@4.7.8)(underscore@1.13.7)
@@ -538,10 +538,10 @@ importers:
         version: ember-cli-babel@7.11.1
       ember-cli-beta:
         specifier: npm:ember-cli@beta
-        version: ember-cli@6.8.0-beta.1(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
+        version: ember-cli@6.8.0-beta.3(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
       ember-cli-fastboot:
         specifier: npm:ember-cli-fastboot@^4.1.0
-        version: 4.1.5(ember-source@6.9.0-alpha.1(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5))
+        version: 4.1.5(ember-source@6.9.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5))
       ember-cli-latest:
         specifier: npm:ember-cli@latest
         version: ember-cli@6.7.0(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7)
@@ -562,13 +562,13 @@ importers:
         version: ember-source@3.28.12(@babel/core@7.28.4)
       ember-source-beta:
         specifier: npm:ember-source@beta
-        version: ember-source@6.8.0-beta.2(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5)
+        version: ember-source@6.8.0-beta.4(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-canary:
         specifier: npm:ember-source@alpha
-        version: ember-source@6.9.0-alpha.1(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5)
+        version: ember-source@6.9.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-latest:
         specifier: npm:ember-source@latest
-        version: ember-source@6.7.0(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5)
+        version: ember-source@6.7.0(@glimmer/component@2.0.0)(rsvp@4.8.5)
       ember-source-lts:
         specifier: npm:ember-source@~3.4.0
         version: ember-source@3.4.8
@@ -578,12 +578,18 @@ importers:
       ember-welcome-page5:
         specifier: npm:ember-welcome-page@^5.0.0
         version: ember-welcome-page@5.0.0(@babel/core@7.28.4)
+      ember-welcome-page8:
+        specifier: npm:ember-welcome-page@^8.0.0
+        version: ember-welcome-page@8.0.3(@babel/core@7.28.4)
       execa:
         specifier: ^5.0.0
         version: 5.1.1
       fs-extra:
         specifier: ^6.0.1
         version: 6.0.1
+      glimmer-component-2:
+        specifier: npm:@glimmer/component@^2.0.0
+        version: '@glimmer/component@2.0.0'
       js-string-escape:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1310,41 +1316,44 @@ packages:
   '@ember-tooling/blueprint-blueprint@0.0.2':
     resolution: {integrity: sha512-W0Ulvny2PT+80qy2X9wSlNTobgfobI3cNfxoDgIlEr1f5ifyUg6rydyErl9RUupPxfsvuya6ss9TV6y86+qOjA==}
 
-  '@ember-tooling/blueprint-blueprint@0.0.3':
-    resolution: {integrity: sha512-NDWlrYmqckdUcGy/0rcx4f5WSBhRFhOXp505A7SzmU1PdfAJYIMlXWRtQwu6M9+V3S4szIHXNWJsQhV3S6Bh9w==}
-
   '@ember-tooling/blueprint-blueprint@0.1.0':
     resolution: {integrity: sha512-TJ+Zyrwkx91WsFXRe8GblidMr9ouiGen7SUJWP6+3K8UfNS2fhfs1GLwyHzN54wCMIJsNxe99dGvy0NTHuipQA==}
+
+  '@ember-tooling/blueprint-blueprint@0.2.0':
+    resolution: {integrity: sha512-Uh9EY8mkSXU55jp3B91Y5Z/Ug1M5cj58H7EXQ+buKPYpcZ8AWEPHohsqAx0xcGR57KpYMPhZrsZjwMHJ3ojaRw==}
 
   '@ember-tooling/blueprint-model@0.0.2':
     resolution: {integrity: sha512-mZ6GZQE3zNfldN0qpZ8qAwCKH2fog60af72yppQueraYqRgL1SSd46An7sxRb1ur60+xlCMZAlj3086Fk1cKuQ==}
 
-  '@ember-tooling/blueprint-model@0.2.0':
-    resolution: {integrity: sha512-OMDtCD1decMgjISIHL3wfl/PkM+rgsPClFgwm1u/AtlR4b4NMm5huKNo3dETiPPjiaHdoylBNNwmrp+GuZg+eA==}
-
   '@ember-tooling/blueprint-model@0.3.0':
     resolution: {integrity: sha512-z9ZjJNgcPZ/+xLQSeGIUbKFl9aw0MUXZtfFgv++8rrP2EVfI9ibTRDdLEYE9ROhQlD2LTogOigBk9AWIFOXKTw==}
+
+  '@ember-tooling/blueprint-model@0.4.0':
+    resolution: {integrity: sha512-8SwhTpsNbil268fnDhA6OPfN6lFAa4/yk2nWlR6ZVuWvw050DmZQo1OxWo0Ya3bU8Ee8KZ8Prfz3YDBs9v0ETw==}
 
   '@ember-tooling/classic-build-addon-blueprint@6.7.0':
     resolution: {integrity: sha512-wNWXdVWy6N9jNtN7dKeZe9IClOWoqJzuPjZSW6+7GTi1JSN8kMmKUQzhvJEAeBne5KStGUyVGlc3073kI7d3Cw==}
 
-  '@ember-tooling/classic-build-addon-blueprint@6.8.0-alpha.5':
-    resolution: {integrity: sha512-+HFOU4oWU+xJDRvbKwrOX90kNz6QeozHiqGLXE+BzY3RADhFTx0OAEzi9WRer8d2XMy11hS5yzKrZnLR/QKAcQ==}
-
   '@ember-tooling/classic-build-addon-blueprint@6.8.0-beta.1':
     resolution: {integrity: sha512-8xU+OfkF4vu85NMzNgupDr4+ZDCGJf3kh5+2FTrpPVLNdPavth03HbmpPI4+heZ3s55oD4gvic+owGuMY39r4A==}
+
+  '@ember-tooling/classic-build-addon-blueprint@6.9.0-alpha.1':
+    resolution: {integrity: sha512-2wMLLkx4EgZiXDoupartCbXMa5SQ1CNPX/WjqOU0IkW62XMwyiquTDF2KEBU5ZunAmkIRiJ/uRMVGCFAEAOigQ==}
 
   '@ember-tooling/classic-build-app-blueprint@6.7.0':
     resolution: {integrity: sha512-Y6vaSlLOOfZtLBHUISZ0LWhiUyEpYaZLe8LHA7m5K7mJ0kkA3GO/YN1VGjrtlEd6yL2aWU4CYYT0tZjDH/UiAw==}
 
-  '@ember-tooling/classic-build-app-blueprint@6.8.0-alpha.5':
-    resolution: {integrity: sha512-xj7thzmVgAsvSWf+tXrfMvdZ/Tq3ugyjo340HBT7MtlK6k95egxxk0fWFF+d7bgerSVnZc1gvKCtWI4O6UmfYw==}
-
   '@ember-tooling/classic-build-app-blueprint@6.8.0-beta.1':
     resolution: {integrity: sha512-oZguKvFo/5dh6kb+JDWqRYLBeZ+ORZzP+m5Dt67sKmnHY6vYlwZ0KJ7u8/lSMb5IzSJUog+OgsAFttVfCzmAbQ==}
 
-  '@ember/app-blueprint@6.8.0-beta.1':
-    resolution: {integrity: sha512-numsThY0m1gXrOSpe4B8luGds0vPi0Jlh4BHltE0nOxX5LwfXGDadeNh1uezfjimuRJmRtPE0EXyX5BOOEpcew==}
+  '@ember-tooling/classic-build-app-blueprint@6.9.0-alpha.1':
+    resolution: {integrity: sha512-hUADX49FRJY/RiiuJYMyrCJp7FZ/FZ515Q3AG2rS7n8mKRicBbu2Q+t8PjeH0UQ8c9DZ1nWLu9r+wP4/VWJFow==}
+
+  '@ember/app-blueprint@6.8.0-beta.3':
+    resolution: {integrity: sha512-YvyGWv5ptYbMt/xGLnjAOhoz49NW5bJTSUhQ67YTbFk2uvm12F5KryL4sdtu+MOJL9gJBT/h8Ew9RYjr8TE42Q==}
+
+  '@ember/app-blueprint@6.9.0-alpha.1':
+    resolution: {integrity: sha512-dXHTkAN9Tunouqe89bpHW5RyTV/xDhUhMsR5Tk9xgYg6i6HsAGNxeMsqj94eKtOdnV/MEcPfjkFO86Cxzj4UAQ==}
 
   '@ember/edition-utils@1.2.0':
     resolution: {integrity: sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==}
@@ -1398,6 +1407,15 @@ packages:
       '@glint/template':
         optional: true
 
+  '@embroider/macros@1.19.1':
+    resolution: {integrity: sha512-KgPan7fiyoDGfr6SMdMELhcgUXK6pU/QICSK0yFFzsXVBJYM2fHAXCic5WCBETtv7xsvi4byziahSz5HpqYs/A==}
+    engines: {node: 12.* || 14.* || >= 16}
+    peerDependencies:
+      '@glint/template': ^1.0.0
+    peerDependenciesMeta:
+      '@glint/template':
+        optional: true
+
   '@embroider/shared-internals@0.40.0':
     resolution: {integrity: sha512-Ovr/i0Qgn6W6jdGXMvYJKlRoRpyBY9uhYozDSFKlBjeEmRJ0Plp7OST41+O5Td6Pqp+Rv2jVSnGzhA/MpC++NQ==}
     engines: {node: 10.* || 12.* || >= 14}
@@ -1412,6 +1430,10 @@ packages:
 
   '@embroider/shared-internals@3.0.0':
     resolution: {integrity: sha512-5J5ipUMCAinQS38WW7wedruq5Z4VnHvNo+ZgOduw0PtI9w0CQWx7/HE+98PBDW8jclikeF+aHwF317vc1hwuzg==}
+    engines: {node: 12.* || 14.* || >= 16}
+
+  '@embroider/shared-internals@3.0.1':
+    resolution: {integrity: sha512-d7RQwDwqqHo7YvjE9t1rtIrCCYtbSoO0uRq2ikVhRh4hGS5OojZNu2ZtS0Wqrg+V72CRtMFr/hibTvHNsRM2Lg==}
     engines: {node: 12.* || 14.* || >= 16}
 
   '@embroider/test-setup@4.0.0':
@@ -1460,6 +1482,10 @@ packages:
   '@glimmer/component@1.1.2':
     resolution: {integrity: sha512-XyAsEEa4kWOPy+gIdMjJ8XlzA3qrGH55ZDv6nA16ibalCR17k74BI0CztxuRds+Rm6CtbUVgheCVlcCULuqD7A==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  '@glimmer/component@2.0.0':
+    resolution: {integrity: sha512-eATSzBOUm0MZ9+YfJx7Y5p3gbwnaeMzLSSsCDn1ihDtUOIm5YYEV0ee0G7tXt/uKxowt8tXYn/EMbI9OlRF0CA==}
+    engines: {node: '>= 18'}
 
   '@glimmer/destroyable@0.94.8':
     resolution: {integrity: sha512-IWNz34Q5IYnh20M/3xVv9jIdCATQyaO+8sdUSyUqiz1bAblW5vTXUNXn3uFzGF+CnP6ZSgPxHN/c1sNMAh+lAA==}
@@ -4143,6 +4169,9 @@ packages:
     resolution: {integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==}
     engines: {node: '>=4'}
 
+  decorator-transforms@2.3.0:
+    resolution: {integrity: sha512-jo8c1ss9yFPudHuYYcrJ9jpkDZIoi+lOGvt+Uyp9B+dz32i50icRMx9Bfa8hEt7TnX1FyKWKkjV+cUdT/ep2kA==}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -4487,13 +4516,13 @@ packages:
     engines: {node: '>= 20.11'}
     hasBin: true
 
-  ember-cli@6.8.0-alpha.5:
-    resolution: {integrity: sha512-enQhk1Y/4iL5gztegXnB/rQyoGyllUO+/zsJ0QFEjCmFjyrqAeABmvtcHNat7ICFVu9s7JbTfpeJNlmaVvFpJg==}
+  ember-cli@6.8.0-beta.3:
+    resolution: {integrity: sha512-J9MvELmpJaRSroRwnBfdLvmgPYmLqWd4QzwlRwJwJYwWogQk31WvWADn7fM6UfoAzmoxIMSKPqqWjzz8rm47sg==}
     engines: {node: '>= 20.11'}
     hasBin: true
 
-  ember-cli@6.8.0-beta.1:
-    resolution: {integrity: sha512-NzR62v8az+/JjJuXfBYZE/qq56lUWhybgJSBgKShTDtw72bRP08ibjyp0xdykSFXs4LasNppEeFxbyjOKO0ysQ==}
+  ember-cli@6.9.0-alpha.1:
+    resolution: {integrity: sha512-X7giBhBR2OBY1SozOa/RpGbaWvRBVcNr/49u0nere0E44cIUnP9YyeSLhR5g9dDZyPH2DpVEyzUIF3ttm0VtZQ==}
     engines: {node: '>= 20.11'}
     hasBin: true
 
@@ -4561,14 +4590,14 @@ packages:
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
 
-  ember-source@6.8.0-beta.2:
-    resolution: {integrity: sha512-i/EdYOonMa4eLtm0q5QAFe+GWq9ddb/yEb3wVv/4NChgj2fmvT7q589sGJTilOlLOlZ72POJTQqsANPuagD6vw==}
+  ember-source@6.8.0-beta.4:
+    resolution: {integrity: sha512-w0aWaPq5BBH9o+HrktEvLTujY8FFXJ89BI9EUAPaOhUIysoYxFedyHZsliWCgnvAXhGUH6f+crmoqcSbCjMkCQ==}
     engines: {node: '>= 18.*'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
 
-  ember-source@6.9.0-alpha.1:
-    resolution: {integrity: sha512-WNn8xkrpeuCY5UNVTmWmPkMe2oyB5SOvXAaGn7x0EjXbFp65vglybXc74xvDZIxdWzeT3ReEYUHxEloXuKn/+w==}
+  ember-source@6.9.0-alpha.6:
+    resolution: {integrity: sha512-H+1WbzMofIsdMaB9zNHud9c/Kt40TUJv5wZ+mWfvaNwPyuOiu29DDQzmOgFpL2U1bRELHWt9+lwnEpexRasO8w==}
     engines: {node: '>= 18.*'}
     peerDependencies:
       '@glimmer/component': '>= 1.1.2'
@@ -4598,6 +4627,9 @@ packages:
   ember-welcome-page@6.2.0:
     resolution: {integrity: sha512-bDPgNgW0eRhLCHLaFK87p1mcP8hGwr0pXvPoskDeUGQzsOI3Pc3U/8WLpUSi2mNrmv0eNtfWqE+A1Wbx6F2l0Q==}
     engines: {node: 12.* || 14.* || >= 16}
+
+  ember-welcome-page@8.0.3:
+    resolution: {integrity: sha512-UhGUp0ZWu+Lprj0Ib3LxkstvslTjPtxyU7Uub1A7LN3awwzoFvvJkbeas4aPN7eINvzPe/c8pjnucDRDiSbMlQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -10456,9 +10488,9 @@ snapshots:
 
   '@ember-tooling/blueprint-blueprint@0.0.2': {}
 
-  '@ember-tooling/blueprint-blueprint@0.0.3': {}
-
   '@ember-tooling/blueprint-blueprint@0.1.0': {}
+
+  '@ember-tooling/blueprint-blueprint@0.2.0': {}
 
   '@ember-tooling/blueprint-model@0.0.2':
     dependencies:
@@ -10472,7 +10504,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-tooling/blueprint-model@0.2.0':
+  '@ember-tooling/blueprint-model@0.3.0':
     dependencies:
       chalk: 4.1.2
       diff: 7.0.0
@@ -10484,7 +10516,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-tooling/blueprint-model@0.3.0':
+  '@ember-tooling/blueprint-model@0.4.0':
     dependencies:
       chalk: 4.1.2
       diff: 7.0.0
@@ -10510,9 +10542,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-tooling/classic-build-addon-blueprint@6.8.0-alpha.5':
+  '@ember-tooling/classic-build-addon-blueprint@6.8.0-beta.1':
     dependencies:
-      '@ember-tooling/blueprint-model': 0.2.0
+      '@ember-tooling/blueprint-model': 0.3.0
       chalk: 4.1.2
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
@@ -10524,9 +10556,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-tooling/classic-build-addon-blueprint@6.8.0-beta.1':
+  '@ember-tooling/classic-build-addon-blueprint@6.9.0-alpha.1':
     dependencies:
-      '@ember-tooling/blueprint-model': 0.3.0
+      '@ember-tooling/blueprint-model': 0.4.0
       chalk: 4.1.2
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-string-utils: 1.1.0
@@ -10546,14 +10578,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember-tooling/classic-build-app-blueprint@6.8.0-alpha.5':
-    dependencies:
-      '@ember-tooling/blueprint-model': 0.2.0
-      chalk: 4.1.2
-      ember-cli-string-utils: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@ember-tooling/classic-build-app-blueprint@6.8.0-beta.1':
     dependencies:
       '@ember-tooling/blueprint-model': 0.3.0
@@ -10562,7 +10586,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ember/app-blueprint@6.8.0-beta.1':
+  '@ember-tooling/classic-build-app-blueprint@6.9.0-alpha.1':
+    dependencies:
+      '@ember-tooling/blueprint-model': 0.4.0
+      chalk: 4.1.2
+      ember-cli-string-utils: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ember/app-blueprint@6.8.0-beta.3':
+    dependencies:
+      chalk: 4.1.2
+      ember-cli-string-utils: 1.1.0
+      lodash: 4.17.21
+      walk-sync: 3.0.0
+
+  '@ember/app-blueprint@6.9.0-alpha.1':
     dependencies:
       chalk: 4.1.2
       ember-cli-string-utils: 1.1.0
@@ -10758,6 +10797,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@embroider/macros@1.19.1':
+    dependencies:
+      '@embroider/shared-internals': 3.0.1
+      assert-never: 1.4.0
+      babel-import-util: 3.0.1
+      ember-cli-babel: 7.26.11
+      find-up: 5.0.0
+      lodash: 4.17.21
+      resolve: 1.22.10
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@embroider/shared-internals@0.40.0':
     dependencies:
       ember-rfc176-data: 0.3.18
@@ -10797,6 +10849,24 @@ snapshots:
       - supports-color
 
   '@embroider/shared-internals@3.0.0':
+    dependencies:
+      babel-import-util: 3.0.1
+      debug: 4.4.1
+      ember-rfc176-data: 0.3.18
+      fs-extra: 9.1.0
+      is-subdir: 1.2.0
+      js-string-escape: 1.0.1
+      lodash: 4.17.21
+      minimatch: 3.1.2
+      pkg-entry-points: 1.1.1
+      resolve-package-path: 4.0.3
+      resolve.exports: 2.0.3
+      semver: 7.7.2
+      typescript-memoize: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@embroider/shared-internals@3.0.1':
     dependencies:
       babel-import-util: 3.0.1
       debug: 4.4.1
@@ -10876,6 +10946,13 @@ snapshots:
       ember-compatibility-helpers: 1.2.7(@babel/core@7.28.4)
     transitivePeerDependencies:
       - '@babel/core'
+      - supports-color
+
+  '@glimmer/component@2.0.0':
+    dependencies:
+      '@embroider/addon-shim': 1.10.0
+      '@glimmer/env': 0.1.7
+    transitivePeerDependencies:
       - supports-color
 
   '@glimmer/destroyable@0.94.8':
@@ -14211,6 +14288,13 @@ snapshots:
     dependencies:
       mimic-response: 1.0.1
 
+  decorator-transforms@2.3.0(@babel/core@7.28.4):
+    dependencies:
+      '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.4)
+      babel-import-util: 3.0.1
+    transitivePeerDependencies:
+      - '@babel/core'
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -14690,7 +14774,7 @@ snapshots:
       resolve: 1.22.10
       semver: 5.7.2
 
-  ember-cli-fastboot@4.1.5(ember-source@6.9.0-alpha.1(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5)):
+  ember-cli-fastboot@4.1.5(ember-source@6.9.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)):
     dependencies:
       broccoli-concat: 4.2.5
       broccoli-file-creator: 2.1.1
@@ -14702,7 +14786,7 @@ snapshots:
       ember-cli-lodash-subset: 2.0.1
       ember-cli-preprocess-registry: 3.3.0
       ember-cli-version-checker: 5.1.2
-      ember-source: 6.9.0-alpha.1(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5)
+      ember-source: 6.9.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5)
       fastboot: 4.1.5(patch_hash=f399fe46775908a599a0998a41aa72bae16315c83fd93ee1a25317e75f0f3979)
       fastboot-express-middleware: 4.1.2
       fastboot-transform: 0.1.3
@@ -15515,13 +15599,13 @@ snapshots:
       - walrus
       - whiskers
 
-  ember-cli@6.8.0-alpha.5(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7):
+  ember-cli@6.8.0-beta.3(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7):
     dependencies:
-      '@ember-tooling/blueprint-blueprint': 0.0.3
-      '@ember-tooling/blueprint-model': 0.2.0
-      '@ember-tooling/classic-build-addon-blueprint': 6.8.0-alpha.5
-      '@ember-tooling/classic-build-app-blueprint': 6.8.0-alpha.5
-      '@ember/app-blueprint': 6.8.0-beta.1
+      '@ember-tooling/blueprint-blueprint': 0.1.0
+      '@ember-tooling/blueprint-model': 0.3.0
+      '@ember-tooling/classic-build-addon-blueprint': 6.8.0-beta.1
+      '@ember-tooling/classic-build-app-blueprint': 6.8.0-beta.1
+      '@ember/app-blueprint': 6.8.0-beta.3
       '@pnpm/find-workspace-dir': 1000.1.2
       babel-remove-types: 1.0.1
       broccoli: 3.5.2
@@ -15661,13 +15745,13 @@ snapshots:
       - walrus
       - whiskers
 
-  ember-cli@6.8.0-beta.1(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7):
+  ember-cli@6.9.0-alpha.1(babel-core@6.26.3)(handlebars@4.7.8)(underscore@1.13.7):
     dependencies:
-      '@ember-tooling/blueprint-blueprint': 0.1.0
-      '@ember-tooling/blueprint-model': 0.3.0
-      '@ember-tooling/classic-build-addon-blueprint': 6.8.0-beta.1
-      '@ember-tooling/classic-build-app-blueprint': 6.8.0-beta.1
-      '@ember/app-blueprint': 6.8.0-beta.1
+      '@ember-tooling/blueprint-blueprint': 0.2.0
+      '@ember-tooling/blueprint-model': 0.4.0
+      '@ember-tooling/classic-build-addon-blueprint': 6.9.0-alpha.1
+      '@ember-tooling/classic-build-app-blueprint': 6.9.0-alpha.1
+      '@ember/app-blueprint': 6.9.0-alpha.1
       '@pnpm/find-workspace-dir': 1000.1.2
       babel-remove-types: 1.0.1
       broccoli: 3.5.2
@@ -15984,13 +16068,13 @@ snapshots:
       - supports-color
       - webpack
 
-  ember-source@6.7.0(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5):
+  ember-source@6.7.0(@glimmer/component@2.0.0)(rsvp@4.8.5):
     dependencies:
       '@babel/core': 7.28.4
       '@ember/edition-utils': 1.2.0
       '@embroider/addon-shim': 1.10.0
       '@glimmer/compiler': 0.94.10
-      '@glimmer/component': 1.1.2(@babel/core@7.28.4)
+      '@glimmer/component': 2.0.0
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
@@ -16031,13 +16115,13 @@ snapshots:
       - rsvp
       - supports-color
 
-  ember-source@6.8.0-beta.2(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5):
+  ember-source@6.8.0-beta.4(@glimmer/component@2.0.0)(rsvp@4.8.5):
     dependencies:
       '@babel/core': 7.28.4
       '@ember/edition-utils': 1.2.0
       '@embroider/addon-shim': 1.10.0
       '@glimmer/compiler': 0.94.11
-      '@glimmer/component': 1.1.2(@babel/core@7.28.4)
+      '@glimmer/component': 2.0.0
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
@@ -16078,13 +16162,13 @@ snapshots:
       - rsvp
       - supports-color
 
-  ember-source@6.9.0-alpha.1(@glimmer/component@1.1.2(@babel/core@7.28.4))(rsvp@4.8.5):
+  ember-source@6.9.0-alpha.6(@glimmer/component@2.0.0)(rsvp@4.8.5):
     dependencies:
       '@babel/core': 7.28.4
       '@ember/edition-utils': 1.2.0
       '@embroider/addon-shim': 1.10.0
       '@glimmer/compiler': 0.94.11
-      '@glimmer/component': 1.1.2(@babel/core@7.28.4)
+      '@glimmer/component': 2.0.0
       '@glimmer/destroyable': 0.94.8
       '@glimmer/global-context': 0.93.4
       '@glimmer/interfaces': 0.94.6
@@ -16200,6 +16284,14 @@ snapshots:
     dependencies:
       '@embroider/addon-shim': 1.10.0
     transitivePeerDependencies:
+      - supports-color
+
+  ember-welcome-page@8.0.3(@babel/core@7.28.4):
+    dependencies:
+      '@embroider/addon-shim': 1.10.0
+      decorator-transforms: 2.3.0(@babel/core@7.28.4)
+    transitivePeerDependencies:
+      - '@babel/core'
       - supports-color
 
   emoji-regex@8.0.0: {}

--- a/test-scenarios/package.json
+++ b/test-scenarios/package.json
@@ -48,6 +48,8 @@
     "ember-source-latest": "npm:ember-source@latest",
     "ember-test-helpers-lts": "npm:@ember/test-helpers@2.6.0",
     "ember-welcome-page5": "npm:ember-welcome-page@^5.0.0",
+    "ember-welcome-page8": "npm:ember-welcome-page@^8.0.0",
+    "glimmer-component-2": "npm:@glimmer/component@^2.0.0",
     "js-string-escape": "^1.0.1",
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.10",

--- a/test-scenarios/smoke-test.ts
+++ b/test-scenarios/smoke-test.ts
@@ -42,8 +42,8 @@ scenarios.forEachScenario(scenario => {
     hooks.before(async () => {
       app = await scenario.prepare();
     });
-    test('yarn test', async function (assert) {
-      let result = await app.execute('pnpm  run test');
+    test('pnpm run test', async function (assert) {
+      let result = await app.execute('pnpm run test');
       assert.equal(result.exitCode, 0, result.output);
     });
   });

--- a/test-scenarios/smoke-test.ts
+++ b/test-scenarios/smoke-test.ts
@@ -1,0 +1,50 @@
+import merge from 'lodash/merge';
+import { appScenarios } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+const { module: Qmodule, test } = QUnit;
+
+let scenarios = appScenarios.only('release').map('smoke-test', project => {
+  /**
+   * We had an issue when @glimmer/component upgraded to be a v2 addon, it wasn't discoverable as an implicit
+   * dependency of other v2 addons. This is a simple bug since we expect all addons to have access to this
+   * dependency without having to declare it as a peerDep
+   */
+  project.linkDevDependency('@glimmer/component', { baseDir: __dirname, resolveName: 'glimmer-component-2' });
+  project.linkDevDependency('ember-welcome-page', { baseDir: __dirname, resolveName: 'ember-welcome-page8' });
+
+  merge(project.files, {
+    tests: {
+      acceptance: {
+        'index-test.js': `
+            import { module, test } from 'qunit';
+            import { visit } from '@ember/test-helpers';
+            import { setupApplicationTest } from 'ember-qunit';
+            module('Acceptance | index', function (hooks) {
+              setupApplicationTest(hooks);
+              test('Renders the Welcome Page', async function (assert) {
+                await visit('/');
+                assert.equal(document.querySelector('#ember-testing h1').textContent.trim(), 'Congratulations, you made it!');
+              });
+            });
+          `,
+      },
+    },
+  });
+
+  project.linkDependency('ember-auto-import', { baseDir: __dirname });
+  project.linkDependency('webpack', { baseDir: __dirname });
+});
+
+scenarios.forEachScenario(scenario => {
+  Qmodule(scenario.name, function (hooks) {
+    let app: PreparedApp;
+    hooks.before(async () => {
+      app = await scenario.prepare();
+    });
+    test('yarn test', async function (assert) {
+      let result = await app.execute('pnpm  run test');
+      assert.equal(result.exitCode, 0, result.output);
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/embroider-build/ember-auto-import/issues/665

You can see that I created a failing test in my first commit and then fixed that test in my second 👍 the only way to recreate this bug is to have an app where the only usage of `@glimmer/component` was coming from a v2 addon so we needed a new scenario that was essentially empty. 